### PR TITLE
Minor update from ArrayList<> to List<>

### DIFF
--- a/backend/src/main/java/com/speakfluid/backend/entities/TalkStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/TalkStep.java
@@ -52,7 +52,7 @@ abstract public class TalkStep {
      * @param speech speech from first speaker
      * @param keywords  list of maps of keyword to weighting, where each map is a keywordCluster
      */
-    public void countMatchKeywords(Speech speech, ArrayList<Map<String, Double>> keywords){
+    public void countMatchKeywords(Speech speech, List<Map<String, Double>> keywords){
         for(Map<String, Double> keywordCluster: keywords){
             for(Map.Entry<String, Double> keyword: keywordCluster.entrySet()){
                 if(speech.getMessage().contains(keyword.getKey())){


### PR DESCRIPTION
made second parameter of countMatchKeyword() from ArrayList<....> to List<....> due to implementation errors from Step entity classes.