### PR TITLE
Implemented Capture and Choice Step entities

### DIFF
--- a/.idea/tli-speakfluid.iml
+++ b/.idea/tli-speakfluid.iml
@@ -2,7 +2,9 @@
 <module type="JAVA_MODULE" version="4">
   <component name="NewModuleRootManager" inherit-compiler-output="true">
     <exclude-output />
-    <content url="file://$MODULE_DIR$" />
+    <content url="file://$MODULE_DIR$">
+      <sourceFolder url="file://$MODULE_DIR$/backend/src/main/java" isTestSource="false" />
+    </content>
     <orderEntry type="inheritedJdk" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>

--- a/backend/src/main/java/com/speakfluid/backend/entities/CaptureStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/CaptureStep.java
@@ -1,0 +1,121 @@
+package com.speakfluid.backend.entities;
+
+import java.lang.String;
+import java.lang.reflect.Array;
+import java.util.*;
+import static java.util.Map.entry;
+
+/**
+ * ChoiceStep analysizes incoming Dialogues to determine the
+ * whether that chatbot output of the Dialogue is suitable for
+ * a Choice Listen Step through a confidence score.
+ *
+ * Choice Listen Step is mainly used for "Yes" and "No" simple responses.
+ *
+ * @author  Sarah Xu
+ * @version 1.0
+ * @since   2022-11-15
+ */
+public class CaptureStep extends TalkStep {
+    private static int scoreAccumulator = 0;
+    private final int maxScore = 25;
+    private double confidenceScore;
+    private final List<Map<String, Double>> captureKeyWordsChatbot =
+            Arrays.asList(
+                    Map.ofEntries(entry("please provide", 5.0), entry("please enter", 5.0), entry("what is your", 5.0),
+                            entry("provide your", 4.0), entry("provide the", 4.0), entry("enter your", 4.0),
+                            entry("enter the", 4.0), entry("provide", 3.0), entry("enter", 3.0)),
+                    Map.ofEntries(entry("email address", 5.0), entry("email", 4.0), entry("e-mail", 4.0)),
+                    Map.ofEntries(entry("order number", 5.0), entry("number", 3.0)),
+                    Map.ofEntries(entry("what time", 5.0), entry("which date", 5.0), entry("which day", 5.0),
+                            entry("when", 3.0), entry("time", 3.0), entry("date", 3.0), entry("day", 3.0)),
+                    Map.ofEntries(entry("address", 5.0), entry("zip code", 5.0), entry("location", 4.0)),
+                    Map.ofEntries(entry("name", 5.0), entry("full name", 5.0), entry("address you", 3.0))
+            );
+
+    // includes special characters, week days, times, address, emails
+    private final List<Map<String, Double>> captureKeyWordsUsers =
+            Arrays.asList(
+                    Map.ofEntries(entry("@", 5.0), entry(".com", 5.0), entry(".org", 5.0),
+                            entry("email", 3.0)),
+                    Map.ofEntries(entry("pm", 5.0), entry("p.m.", 5.0), entry("a.m.", 5.0),
+                            entry("am", 5.0), entry("night", 5.0), entry("noon", 5.0),
+                            entry("morning.", 5.0), entry("time", 3.0), entry("available", 3.0)),
+                    Map.ofEntries(entry("monday", 5.0), entry("tuesday", 5.0), entry("wednesday", 5.0),
+                            entry("thursday", 5.0), entry("friday", 5.0), entry("saturday", 5.0),
+                            entry("sunday.", 5.0), entry("tomorrow", .0), entry("today", 4.0),
+                            entry("tonight", 4.0), entry("weekend", 4.0)),
+                    Map.ofEntries(entry("address", 5.0), entry("zip code", 5.0), entry("location", 4.0),
+                            entry("home", 4.0), entry("zip", 3.0), entry("code", 3.0))
+            );
+
+
+    /**
+     * hasNumbers() is used for situation where a user inputs numbers,
+     * such as for phone number, address, date, time, email, etc. which
+     * are indications that a capture step should be used to capture these
+     * specific, or personal information.
+     * @param speech one message from user
+     */
+    public void hasNumbers(Speech speech){
+        for(String word : speech.getMessage().split(" ")){
+            if(speech.getMessage().matches(".*[0-9].*")){
+                scoreAccumulator += 3;
+            }
+        }
+    }
+
+    /**
+     * isEmail() is checks if user provides an email address,
+     * and adds 10 to scoreAccumulator because it is important
+     * to use the Capture Step here.
+     * @param speech one message from user
+     */
+    public void isEmail(Speech speech){
+        for(String word : speech.getMessage().split(" ")){
+            if(speech.getMessage().matches("\\A[A-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[A-Z0-9.-]+\\Z")){
+                scoreAccumulator += 10;
+            }
+        }
+    }
+
+    /**
+     * isZipCode() is used for situation where a user provides
+     * their zipcode. The current method checks for US and Canadian ZipCodes
+     * @param speech one message from user
+     */
+    public void isZipCode(Speech speech){
+        for(String word : speech.getMessage().split(" ")){
+            if(speech.getMessage().matches( "^\\d{5}([-+]?\\d{4})?$")
+                    || speech.getMessage().matches( "/^[A-Za-z]\\d[A-Za-z][ -]?\\d[A-Za-z]\\d$/")){
+                scoreAccumulator += 10;
+                break;
+            }
+        }
+    }
+
+    /**
+     * runAnalysis() takes in a Dialogue object and analyses
+     * whether the Capture Step is an appropriate ListenStep here.
+     * It increases scoreAccumulator once there is a sign that
+     * the dialogue is compatible with a Capture Step.
+     * @param dialogue one back and forth between chatbot and user
+     */
+    public void runAnalysis(Dialogue dialogue){
+        // Chatbot messages
+        for (Speech chatbotMessage : dialogue.getChatBotMessage()){
+            countMatchKeywords(chatbotMessage, captureKeyWordsChatbot);
+        }
+        // User messages
+        for (Speech userMessage : dialogue.getUserMessage()){
+            countMatchKeywords(userMessage, captureKeyWordsChatbot);
+            if(calculateMsgLength(userMessage) <= 3) {
+                scoreAccumulator += 5;
+            }
+            hasNumbers(userMessage);
+            isZipCode(userMessage);
+            isEmail(userMessage);
+        }
+    }
+
+}

--- a/backend/src/main/java/com/speakfluid/backend/entities/CaptureStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/CaptureStep.java
@@ -13,12 +13,13 @@ import static java.util.Map.entry;
  * Choice Listen Step is mainly used for "Yes" and "No" simple responses.
  *
  * @author  Sarah Xu
- * @version 1.0
- * @since   2022-11-15
+ * @version 2.0
+ * @since   2022-11-16
  */
 public class CaptureStep extends TalkStep {
-    private static int scoreAccumulator = 0;
-    private final int maxScore = 25;
+    private final String stepName = "Capture";
+    private int scoreAccumulator = 0;
+    private final int maxScore = 30;
     private double confidenceScore;
     private final List<Map<String, Double>> captureKeyWordsChatbot =
             Arrays.asList(
@@ -32,6 +33,10 @@ public class CaptureStep extends TalkStep {
                     Map.ofEntries(entry("address", 5.0), entry("zip code", 5.0), entry("location", 4.0)),
                     Map.ofEntries(entry("name", 5.0), entry("full name", 5.0), entry("address you", 3.0))
             );
+
+    public CaptureStep(){
+        this.scoreAccumulator = 0;
+    }
 
     // includes special characters, week days, times, address, emails
     private final List<Map<String, Double>> captureKeyWordsUsers =
@@ -61,6 +66,7 @@ public class CaptureStep extends TalkStep {
         for(String word : speech.getMessage().split(" ")){
             if(speech.getMessage().matches(".*[0-9].*")){
                 scoreAccumulator += 3;
+                break;
             }
         }
     }
@@ -75,6 +81,7 @@ public class CaptureStep extends TalkStep {
         for(String word : speech.getMessage().split(" ")){
             if(speech.getMessage().matches("\\A[A-Z0-9_!#$%&'*+/=?`{|}~^.-]+@[A-Z0-9.-]+\\Z")){
                 scoreAccumulator += 10;
+                break;
             }
         }
     }

--- a/backend/src/main/java/com/speakfluid/backend/entities/ChoiceStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/ChoiceStep.java
@@ -1,0 +1,60 @@
+package com.speakfluid.backend.entities;
+
+import java.lang.String;
+import static java.util.Map.entry;
+import java.util.*;
+
+/**
+ * ChoiceStep analysizes incoming Dialogues to determine the
+ * whether that chatbot output of the Dialogue is suitable for
+ * a Choice Listen Step through a confidence score.
+ *
+ * Choice Listen Step is mainly used for "Yes" and "No" simple responses.
+ *
+ * @author  Sarah Xu
+ * @version 1.0
+ * @since   2022-11-15
+ */
+public class ChoiceStep extends TalkStep {
+    private static int scoreAccumulator = 0;
+    private final int maxScore = 25;
+    private double confidenceScore;
+    private final List<Map<String, Double>> choiceKeyWordsChatbot =
+            Arrays.asList(
+                    Map.ofEntries(entry("would you like", 5.0), entry("would you", 4.5)),
+                    Map.ofEntries(entry("can i", 5.0), entry("should i", 5.0), entry("could i", 5.0),
+                            entry("could", 1.0), entry("can", 1.0)),
+                    Map.ofEntries(entry("return to main", 5.0), entry("end conversation", 5.0)),
+                    Map.ofEntries(entry("is this", 4.0), entry("is that", 4.0), entry("may", 2.0))
+            );
+
+    private final List<Map<String, Double>> choiceKeyWordsUser =
+            Arrays.asList(
+                    Map.ofEntries(entry("yes", 5.0), entry("yeah", 4.0), entry("okay", 4.0),
+                            entry("ok", 4.0), entry("sure", 3.0), entry("yeh", 2.0), entry("kk", 2.0)),
+                    Map.ofEntries(entry("no", 5.0), entry("nope", 4.0), entry("nah", 3.0),
+                            entry("not", 2.0))
+            );
+
+    /**
+     * runAnalysis() takes in a Dialogue object and analyses
+     * whether the ChoiceStep is an appropriate ListenStep here.
+     * It increases scoreAccumulator once there is a sign that
+     * the dialogue is compatible with a Choice Step.
+     * @param dialogue one back and forth between chatbot and user
+     */
+    public void runAnalysis(Dialogue dialogue){
+        // Chatbot messages
+        for (Speech chatbotMessage : dialogue.getChatBotMessage()){
+            countMatchKeywords(chatbotMessage, choiceKeyWordsChatbot);
+        }
+        // User messages
+        for (Speech userMessage : dialogue.getUserMessage()){
+            countMatchKeywords(userMessage, choiceKeyWordsUser);
+            if(calculateMsgLength(userMessage) <= 3) {
+                scoreAccumulator += 7;
+            }
+        }
+    }
+
+}

--- a/backend/src/main/java/com/speakfluid/backend/entities/ChoiceStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/ChoiceStep.java
@@ -12,12 +12,13 @@ import java.util.*;
  * Choice Listen Step is mainly used for "Yes" and "No" simple responses.
  *
  * @author  Sarah Xu
- * @version 1.0
- * @since   2022-11-15
+ * @version 2.0
+ * @since   2022-11-16
  */
 public class ChoiceStep extends TalkStep {
-    private static int scoreAccumulator = 0;
-    private final int maxScore = 25;
+    private final String stepName = "Choice";
+    private int scoreAccumulator = 0;
+    private final int maxScore = 20;
     private double confidenceScore;
     private final List<Map<String, Double>> choiceKeyWordsChatbot =
             Arrays.asList(
@@ -35,6 +36,10 @@ public class ChoiceStep extends TalkStep {
                     Map.ofEntries(entry("no", 5.0), entry("nope", 4.0), entry("nah", 3.0),
                             entry("not", 2.0))
             );
+
+    public ChoiceStep(){
+        this.scoreAccumulator = 0;
+    }
 
     /**
      * runAnalysis() takes in a Dialogue object and analyses


### PR DESCRIPTION
**CaptureStep** Notes and Discussion Points:
Notes:
1. Chatbot keywords contain themes: email, order number, time/date, address, name, asking for information (e.g. "please provide")
2. User keywords contain themes: email (@ .com), times/date (PM, AM, Monday), Address
3. hasNumbers(), isZipCode(), isEmail() use regular expressions for checking numbers (e.g. phone, order number, insturction), zip codes, and emails 
Points for discussion:
1. In runAnalysis(), I included both the search for keywords (@ .com email) AND isEmail(). That means, if a user did enter an email, the score for using an email would be counted twice. I kept it this way for now because I thought the keyword each was much weaker than the RegEx isEmail() search, so it acts as a double security. And what can go wrong if the score is high? We know it's an email and thus we recommend a capture step for sure. This applies for email, number, and zipcode.
Let me know your thoughts:

**ChoiceStep** notes:
1. ChoiceStep just uses the predefined common analysis methods from TalkStep, and runs them in runAnalysis() 
2. The keywords are ranked from high -> low in weighting, highest 5, lowest 1. This way then the for loop breaks because a keyword matched, the highest score is added to scoreAccumulator. 
3. ChoiceStep is mainly for identifying when users answer "Yes" or "No", since according to voiceflow's blog, is it's usage.