### PR TITLE
Changed names of entities to better describe role and modified return…

### DIFF
--- a/backend/src/main/java/com/speakfluid/backend/entities/ConfidenceScoreCalculator.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/ConfidenceScoreCalculator.java
@@ -1,15 +1,15 @@
 package com.speakfluid.backend.entities;
 
 /**
- * StepManager is responsible for calling every method for each child of TalkStep to increment or decrement their
+ * ConfidenceScoreCalculator is responsible for calling every method for each child of TalkStep to increment or decrement their
  * corresponding accumulated scores as necessary. It then returns the confidence score of the TalkStep child based on the
  * inputted Dialogue object.
  * @author Aurora Zhang
- * @version 1.0
+ * @version 2.0
  * @since November 16th, 2022
  */
 
-public class StepManager implements Scorable{
+public class ConfidenceScoreCalculator implements Scorable{
     double stepScoreAccumulator;
     double stepTotalScore;
 

--- a/backend/src/main/java/com/speakfluid/backend/entities/ConfidenceScoreOptimizer.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/ConfidenceScoreOptimizer.java
@@ -1,0 +1,78 @@
+package com.speakfluid.backend.entities;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+/**
+ * ConfidenceScoreOptimizer calls the ConfidenceScoreOptimizer to store each talk step's confidence score. It then returns a Hashmap mapping
+ * the talk step with the highest confidence score to its confidence score. This class is called by the use case interactor.
+ * @author Aurora Zhang
+ * @version 2.0
+ * @since November 16th, 2022
+ */
+public class ConfidenceScoreOptimizer {
+
+    ArrayList<TalkStep> steps;
+    HashMap<String, Double> talkStepToScoreMapping = new HashMap<>();
+    HashMap<String, Double> suggestedTalkStep = new HashMap<>();
+    ConfidenceScoreCalculator confidenceScoreCalculator;
+    Double stepConfidenceScore;
+    Double highestConfidenceScore;
+    List<String> topThreeSteps;
+
+    public ConfidenceScoreOptimizer(ConfidenceScoreCalculator manager, ArrayList<TalkStep> stepList) {
+        this.confidenceScoreCalculator = manager;
+        this.steps = stepList;
+    }
+
+    /**
+     * Calls the ConfidenceScoreCalculator object to implement all methods for each TalkStep and store the
+     * returned confidence score in the talkStepToScoreMapping HashMap to keep track of the
+     * talk step to its confidence score
+     * @param dialogue the dialogue ArrayList containing the Speeches of the user and chatbot
+     */
+    public void callConfidenceScoreCalculator(Dialogue dialogue){
+        for(TalkStep talkStep: steps){
+            confidenceScoreCalculator.passDialogueToTalkStep(dialogue, talkStep);
+            stepConfidenceScore = confidenceScoreCalculator.calculateConfidenceScore();
+            talkStepToScoreMapping.put(talkStep.getStepName(), stepConfidenceScore);
+        }
+    }
+
+    /**
+     * Returns the talk step with the highest confidence score from the talkStepToScoreMapping if the confidence score is
+     * above 70%. Otherwise returns the top three choices with the top three confidence scores.
+     *
+     * @return String returns the suggested talk step as a String.
+     */
+    public HashMap<String, Double> findSuggestedTalkStep() {
+        highestConfidenceScore = Collections.max(talkStepToScoreMapping.values());
+
+        if(highestConfidenceScore >= 70) {
+            for(Map.Entry<String, Double> entry: talkStepToScoreMapping.entrySet()) {
+                if(Objects.equals(entry.getValue(), highestConfidenceScore)){
+                    suggestedTalkStep.put(entry.getKey(), entry.getValue());
+                    return suggestedTalkStep;
+                }
+            }
+        }
+        else{
+            //Get top 3 keys (talk steps) of a map with top 3 highest confidence scores
+            topThreeSteps = talkStepToScoreMapping.entrySet().stream()
+                    .sorted(Map.Entry.<String, Double>comparingByValue().reversed()).
+                    limit(3).map(Map.Entry::getKey).collect(Collectors.toList());
+            // iterate through talkStepToScoreMapping to find corresponding values and add them to
+            //the returned suggestedTalkStep HashMap
+            for (String topThreeStep : topThreeSteps) {
+                for (Map.Entry<String, Double> entry : talkStepToScoreMapping.entrySet()) {
+                    if (entry.getKey().equals(topThreeStep)) {
+                        suggestedTalkStep.put(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+            return suggestedTalkStep;
+        }
+        return suggestedTalkStep;
+    }
+
+}

--- a/backend/src/main/java/com/speakfluid/backend/entities/SuggestionManager.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/SuggestionManager.java
@@ -14,12 +14,12 @@ public class SuggestionManager {
     ArrayList<TalkStep> steps;
     HashMap<String, Double> talkStepToScoreMapping = new HashMap<>();
     HashMap<String, Double> suggestedTalkStep = new HashMap<>();
-    StepManager stepManager;
+    ConfidenceScoreCalculator confidenceScoreCalculator;
     Double stepConfidenceScore;
     Double highestConfidenceScore;
 
-    public SuggestionManager(StepManager manager, ArrayList<TalkStep> stepList) {
-        this.stepManager = manager;
+    public SuggestionManager(ConfidenceScoreCalculator calculator, ArrayList<TalkStep> stepList) {
+        this.confidenceScoreCalculator = calculator;
         this.steps = stepList;
     }
 
@@ -31,8 +31,8 @@ public class SuggestionManager {
      */
     public void callStepManager(Dialogue dialogue){
         for(TalkStep talkStep: steps){
-            stepManager.passDialogueToTalkStep(dialogue, talkStep);
-            stepConfidenceScore = stepManager.calculateConfidenceScore();
+            confidenceScoreCalculator.passDialogueToTalkStep(dialogue, talkStep);
+            stepConfidenceScore = confidenceScoreCalculator.calculateConfidenceScore();
             talkStepToScoreMapping.put(talkStep.getStepName(), stepConfidenceScore);
         }
     }

--- a/backend/src/main/java/com/speakfluid/backend/usecases/TranscriptAnalysisInteractor.java
+++ b/backend/src/main/java/com/speakfluid/backend/usecases/TranscriptAnalysisInteractor.java
@@ -36,8 +36,8 @@ public class TranscriptAnalysisInteractor implements TranscriptAnalysisInputBoun
                     carouselStep, textStep, choiceStep, cardStep));
 
     // Generate StepManager and SuggestionManager
-    StepManager stepManager = new StepManager();
-    SuggestionManager suggestionManager = new SuggestionManager(stepManager, steps);
+    ConfidenceScoreCalculator confidenceScoreCalculator = new ConfidenceScoreCalculator();
+    SuggestionManager suggestionManager = new SuggestionManager(confidenceScoreCalculator, steps);
 
 
     /**


### PR DESCRIPTION
Notes on this PR:
-changed names of StepManager --> ConfidenceScoreCalculator and 
SuggestionManager --> ConfidenceScoreOptimizer to better satisfy their responsibilities as entities. We talked to Paul about this and he suggested names such as these. 

-implemented in the ConfidenceScoreOptimizer a new condition that if the highest talk step's confidence score is less than 70%, then the top three results are returned instead. This makes sense because we are suggesting a variety of suitable talk steps when there is no clear one, and the user can make a informed choice accordingly. 

I did some research on this and anything above and including 70% is a highly probable answer that will fulfill the user's query according to this Microsoft resource: 
https://learn.microsoft.com/en-us/azure/cognitive-services/qnamaker/concepts/confidence-score 

You can read my comments and documentations if you have any questions or concerns!