### PR TITLE
Implemented Testing for ButtonStep, CardStep, ConfidenceScoreCalculat…

### DIFF
--- a/backend/src/main/java/com/speakfluid/backend/entities/ConfidenceScoreCalculator.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/ConfidenceScoreCalculator.java
@@ -1,10 +1,11 @@
 package com.speakfluid.backend.entities;
+import com.speakfluid.backend.entities.message.*;
+import com.speakfluid.backend.entities.steps.*;
 
-import com.speakfluid.backend.entities.message.Dialogue;
-import com.speakfluid.backend.entities.steps.TalkStep;
+import java.lang.Math.*;
 
 /**
- * ConfidenceScoreCalculator is responsible for calling every method for each child of TalkStep to increment or decrement their
+ * ConfidenceScoreCalculator is responsible for calling every method for each child of TalkStep to adjust their
  * corresponding accumulated scores as necessary. It then returns the confidence score of the TalkStep child based on the
  * inputted Dialogue object.
  * @author Aurora Zhang
@@ -24,7 +25,7 @@ public class ConfidenceScoreCalculator implements Scorable{
      * @param step the type of the talk step whose methods are called.
      */
 
-    public void passDialogueToTalkStep(Dialogue dialogue, TalkStep step) {
+    public void passDialogueToTalkStep(Dialogue<?> dialogue, TalkStep step) {
         step.runAnalysis(dialogue);
         stepTotalScore = step.getMaxScore();
         stepScoreAccumulator = step.getScoreAccumulator();
@@ -32,12 +33,21 @@ public class ConfidenceScoreCalculator implements Scorable{
     }
 
     /**
-     * Calculates the confidence score of the talk step.
+     * Calculates the confidence score of the talk step. If it exceeds 100%, then
+     * 95% will be returned as a capping mechanism.
      * @return returns the confidence score of the talk step.
      */
     @Override
     public double calculateConfidenceScore() {
-        return (stepScoreAccumulator / stepTotalScore) * 100;
+
+        if(((stepScoreAccumulator / stepTotalScore) * 100) > 100){
+            return 95.0;
+
+        }
+        else{
+            double confidenceScore = (stepScoreAccumulator / stepTotalScore) * 100;
+            return Math.round(confidenceScore * 100.0) / 100.0;
+        }
     }
 
 }

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/ButtonStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/ButtonStep.java
@@ -1,7 +1,7 @@
 package com.speakfluid.backend.entities.steps;
-
-import com.speakfluid.backend.entities.message.Dialogue;
-import com.speakfluid.backend.entities.message.Message;
+import com.speakfluid.backend.entities.message.*;
+import com.speakfluid.backend.entities.steps.*;
+import com.speakfluid.backend.entities.*;
 
 import java.util.List;
 import java.util.Arrays;
@@ -14,14 +14,14 @@ import static java.util.Map.entry;
  * the usefulness of a button for this step in the conversational flow. It implements the TalkStep abstract class
  * and inherits all of its attributes and methods.
  * @author Aurora Zhang
- * @version 1.0
+ * @version 3.0
  * @since November 16th 2022
  */
 
-public class ButtonStep extends TalkStep {
+public class ButtonStep extends TalkStep{
 
     private double scoreAccumulator;
-    private final double maxScore = 22.0;
+    private final double maxScore = ScoreStandards.standardStepClass;
     private final String stepName = "Button";
 
 
@@ -29,17 +29,21 @@ public class ButtonStep extends TalkStep {
         this.scoreAccumulator = 0.0;
     }
     private final List<Map<String, Double>> chatbotKeywordsScoreMap = Arrays.asList(
-            Map.ofEntries(entry("would you", 5.0),
-                    entry("what type", 4.0), entry("what kind", 2.0), entry("are you", 4.0),
-                    entry("would it", 4.0),entry("here are", 2.0), entry("do you", 2.0),
-                    entry("here is", 2.0)),
-            Map.ofEntries(entry("here are", 4.0), entry("choose", 4.0), entry("select", 4.0)),
-            Map.ofEntries(entry("destination", 3.0), entry("date", 3.0), entry("departure", 3.0),
-                    entry("arriving", 3.0)));
+            Map.ofEntries(entry("would you", ScoreStandards.highMatch), entry("would it", ScoreStandards.highMatch),
+                    entry("what type", ScoreStandards.mediumMatch), entry("what kind", ScoreStandards.mediumMatch),
+                    entry("are you", ScoreStandards.mediumMatch), entry("do you", ScoreStandards.lowMatch),
+                    entry("here is", ScoreStandards.lowMatch)),
+            Map.ofEntries(entry("here are", ScoreStandards.highMatch), entry("choose", ScoreStandards.highMatch),
+                    entry("select", ScoreStandards.highMatch)),
+            Map.ofEntries(entry("destination", ScoreStandards.mediumMatch), entry("date", ScoreStandards.mediumMatch),
+                    entry("departure", ScoreStandards.mediumMatch),
+                    entry("arriving", ScoreStandards.mediumMatch)));
     private final List<Map<String, Double>> userKeywordsScoreMap = Arrays.asList(
-            Map.ofEntries(entry("booking", 2.0),
-                    entry("train", 2.0), entry("go to", 2.0), entry("arrive", 2.0)),
-            Map.ofEntries(entry("hotel", 4.0), entry("cheap", 4.0), entry("hospital", 4.0)));
+            Map.ofEntries(entry("booking", ScoreStandards.lowMatch),
+                    entry("train", ScoreStandards.lowMatch), entry("go to", ScoreStandards.lowMatch),
+                    entry("arrive", ScoreStandards.lowMatch)),
+            Map.ofEntries(entry("hotel", ScoreStandards.highMatch), entry("cheap", ScoreStandards.highMatch),
+                    entry("hospital", ScoreStandards.highMatch)));
 
     /**
      * runs each method to analyze both the user and chatbot output to see whether this dialogue is
@@ -48,20 +52,20 @@ public class ButtonStep extends TalkStep {
      */
 
     @Override
-    public void runAnalysis(Dialogue dialogue) {
+    public void runAnalysis(Dialogue<?> dialogue) {
         for(Object message: dialogue.getChatBotMessage()){
-            countMatchKeywords((Message) message, chatbotKeywordsScoreMap);
+            this.scoreAccumulator += countMatchKeywords((Message) message, chatbotKeywordsScoreMap);
             int chatbotMsgLength = calculateMsgLength((Message) message);
-            if(chatbotMsgLength < 10){
-                scoreAccumulator += 2;
+            if(chatbotMsgLength < 10 && chatbotMsgLength > 2){
+                this.scoreAccumulator += 2;
             }
 
         }
         for(Object message: dialogue.getUserMessage()){
-            countMatchKeywords((Message) message, userKeywordsScoreMap);
+            this.scoreAccumulator += countMatchKeywords((Message) message, userKeywordsScoreMap);
             int userMsgLength = calculateMsgLength((Message) message);
             // if the user response is short, then this suggests buttons are suitable
-            if(userMsgLength <= 5){
+            if(userMsgLength <= 5 && userMsgLength > 1){
                 this.scoreAccumulator += 2;
             }
 

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/CardStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/CardStep.java
@@ -1,7 +1,7 @@
 package com.speakfluid.backend.entities.steps;
-
-import com.speakfluid.backend.entities.message.Dialogue;
-import com.speakfluid.backend.entities.message.Message;
+import com.speakfluid.backend.entities.message.*;
+import com.speakfluid.backend.entities.steps.*;
+import com.speakfluid.backend.entities.*;
 
 import java.util.*;
 
@@ -12,13 +12,13 @@ import static java.util.Map.entry;
  * these calculations to adjust the score accumulator as necessary for a max score of 20.0. This is in adherence to the
  * CRC card designs.
  * @author Aurora Zhang
- * @version 1.0
+ * @version 3.0
  * @since November 16th, 2022
  */
 
-public class CardStep extends TalkStep {
+public class CardStep extends TalkStep{
     private double scoreAccumulator;
-    private final double maxScore = 25.0;
+    private final double maxScore = ScoreStandards.standardStepClass;
     private final String stepName = "Card";
 
     public CardStep(){
@@ -27,40 +27,43 @@ public class CardStep extends TalkStep {
     }
 
     private final List<Map<String, Double>> chatbotKeywordsScoreMap = Arrays.asList(
-            Map.ofEntries(entry("can i help", 5.0),
-                    entry("can i do", 4.0)),
-            Map.ofEntries(entry("here are", 3.0), entry("there are", 3.0),
-                    entry("what kind", 3.0), entry("do you", 2.0),
-                    entry("here is", 2.0)),
-            Map.ofEntries(entry("ticket", 3.0), entry("area", 3.0), entry("departure", 3.0),
-                    entry("leaves", 3.0)),
-            Map.ofEntries(entry("image", 4.0), entry("picture", 4.0)),
-            Map.ofEntries(entry("choose", 4.0), entry("select", 4.0), entry("pick", 4.0)));
+            Map.ofEntries(entry("can i help", ScoreStandards.highMatch),
+                    entry("can i do", ScoreStandards.mediumMatch)),
+            Map.ofEntries(entry("here are", ScoreStandards.mediumMatch), entry("there are", ScoreStandards.mediumMatch),
+                    entry("what kind", ScoreStandards.mediumMatch), entry("do you", ScoreStandards.lowMatch),
+                    entry("here is", ScoreStandards.lowMatch)),
+            Map.ofEntries(entry("ticket", ScoreStandards.mediumMatch), entry("area", ScoreStandards.mediumMatch),
+                    entry("departure", ScoreStandards.mediumMatch),
+                    entry("leaves", ScoreStandards.mediumMatch)),
+            Map.ofEntries(entry("image", ScoreStandards.highMatch), entry("picture", ScoreStandards.highMatch)),
+            Map.ofEntries(entry("choose", ScoreStandards.highMatch), entry("select", ScoreStandards.highMatch),
+                    entry("pick", ScoreStandards.highMatch)));
     private final List<Map<String, Double>> userKeywordsScoreMap = Arrays.asList(
-            Map.ofEntries(entry("museum", 5.0),
-                    entry("gallery", 4.0), entry("restaurant", 4.0), entry("hospital", 4.0), entry("clinic", 3.0),
-                    entry("hotel", 3.0), entry("attraction", 3.0),
-                    entry("entertainment", 3.0), entry("food", 3.0)),
-            Map.ofEntries(entry("bus", 5.0), entry("taxi", 5.0),
-                    entry("train", 5.0)));
+            Map.ofEntries(entry("museum", ScoreStandards.highMatch),
+                    entry("gallery", ScoreStandards.highMatch), entry("restaurant", ScoreStandards.highMatch),
+                    entry("hospital", ScoreStandards.highMatch), entry("clinic", ScoreStandards.mediumMatch),
+                    entry("hotel", ScoreStandards.mediumMatch), entry("attraction", ScoreStandards.mediumMatch),
+                    entry("entertainment", ScoreStandards.mediumMatch), entry("food", ScoreStandards.mediumMatch)),
+            Map.ofEntries(entry("bus", ScoreStandards.highMatch), entry("taxi", ScoreStandards.highMatch),
+                    entry("train", ScoreStandards.highMatch)));
 
     @Override
-    public void runAnalysis(Dialogue dialogue) {
+    public void runAnalysis(Dialogue<?> dialogue) {
         //match the keywords for both the user and chatbot outputs in the dialogue
         for(Object message: dialogue.getChatBotMessage()){
-            countMatchKeywords((Message) message, chatbotKeywordsScoreMap);
-            double chatbotMsgLength = calculateMsgLength((Message) message);
-            // if the chatbot outputs a shorter message, this suggests buttons with a image are more suitable
-            if(chatbotMsgLength < 10){
+            this.scoreAccumulator += countMatchKeywords((Message) message, chatbotKeywordsScoreMap);
+            int chatbotMsgLength = calculateMsgLength((Message) message);
+            // if the chatbot outputs a shorter message, this suggests buttons with images are more suitable
+            if(chatbotMsgLength < 10 && chatbotMsgLength > 1){
                 this.scoreAccumulator += 2;
             }
 
         }
         for(Object message: dialogue.getUserMessage()){
-            countMatchKeywords((Message) message, userKeywordsScoreMap);
-            double userMsgLength = calculateMsgLength((Message) message);
-            if(userMsgLength < 15){
-                scoreAccumulator += 2;
+            this.scoreAccumulator += countMatchKeywords((Message) message, userKeywordsScoreMap);
+            int userMsgLength = calculateMsgLength((Message) message);
+            if(userMsgLength < 15 && userMsgLength >= 4){
+                this.scoreAccumulator += 2;
             }
 
         }

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/CarouselStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/CarouselStep.java
@@ -1,8 +1,9 @@
 package com.speakfluid.backend.entities.steps;
 
-import com.speakfluid.backend.entities.ScoreStandards;
-import com.speakfluid.backend.entities.message.Dialogue;
-import com.speakfluid.backend.entities.message.Message;
+import com.speakfluid.backend.entities.*;
+import com.speakfluid.backend.entities.message.*;
+import com.speakfluid.backend.entities.steps.*;
+
 
 import java.util.Arrays;
 import java.util.List;
@@ -84,7 +85,7 @@ public class CarouselStep extends TalkStep {
             scoreAccumulator += countMatchKeywords((Message) message, imageKeyWords);
             scoreAccumulator += countMatchKeywords((Message) message, buttonKeyWords);
             if (scoreAccumulator != 0.0 &&
-                    calculateMsgLength((Message) message) <= 6){
+                    calculateMsgLength((Message) message) <= 6 && calculateMsgLength((Message) message) > 1){
                 scoreAccumulator += ScoreStandards.lowMatch;
             }
         }

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/ChoiceStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/ChoiceStep.java
@@ -78,7 +78,7 @@ public class ChoiceStep extends TalkStep {
         // User messages
         for (Object userMessage : dialogue.getUserMessage()){
             scoreAccumulator += countMatchKeywords((Message) userMessage, choiceKeyWordsUser);
-            if(calculateMsgLength((Message) userMessage) <= 3) {
+            if(calculateMsgLength((Message) userMessage) <= 3 && calculateMsgLength((Message) userMessage) > 1) {
                 scoreAccumulator += 3.0;
             }
         }

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/ImageStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/ImageStep.java
@@ -3,7 +3,7 @@ package com.speakfluid.backend.entities.steps;
 import com.speakfluid.backend.entities.ScoreStandards;
 import com.speakfluid.backend.entities.message.Dialogue;
 import com.speakfluid.backend.entities.message.Message;
-import com.speakfluid.backend.entities.steps.TalkStep;
+import com.speakfluid.backend.entities.steps.*;
 
 import java.util.Arrays;
 import java.util.List;
@@ -33,6 +33,7 @@ public class ImageStep extends TalkStep {
                     entry("here are possible the directions", ScoreStandards.highMatch),
                     entry("map", ScoreStandards.mediumMatch), entry("location", 3.0),entry("direction", 3.0)
                     ),
+
             Map.ofEntries(entry("here is a picture", ScoreStandards.highMatch),
                     entry("here is an image", ScoreStandards.highMatch),
                     entry("picture", ScoreStandards.highMatch),entry("illustration", ScoreStandards.highMatch),
@@ -87,7 +88,9 @@ public class ImageStep extends TalkStep {
         for (Object message : dialogue.getChatBotMessage()) {
             scoreAccumulator += countMatchKeywords((Message) message, imageKeyWordsBot);
             if (scoreAccumulator != 0.0 &&
-                    calculateMsgLength((Message) message) <= 6){
+
+                    calculateMsgLength((Message) message) <= 6 && calculateMsgLength((Message) message) > 1){
+
                 scoreAccumulator += ScoreStandards.lowMatch;
             }
         }
@@ -98,4 +101,6 @@ public class ImageStep extends TalkStep {
         }
     }
 
+
 }
+

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/TextStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/TextStep.java
@@ -123,7 +123,8 @@ public class TextStep extends TalkStep {
         for (Object message : dialogue.getChatBotMessage()) {
             scoreAccumulator += countMatchKeywords((Message) message, textKeyWordsChatBot);
             scoreAccumulator += isNotQuestion((Message) message);
-            if (scoreAccumulator != 0.0 && calculateMsgLength((Message) message) >= 8) {
+            if (scoreAccumulator != 0.0 && calculateMsgLength((Message) message) >= 8 &&
+                    calculateMsgLength((Message) message) > 1) {
                 scoreAccumulator += ScoreStandards.lowMatch;
             }
         }

--- a/backend/src/main/java/com/speakfluid/backend/usecases/WozTranscriptAnalysisInteractor.java
+++ b/backend/src/main/java/com/speakfluid/backend/usecases/WozTranscriptAnalysisInteractor.java
@@ -2,6 +2,7 @@ package com.speakfluid.backend.usecases;
 
 import com.speakfluid.backend.entities.*;
 import com.speakfluid.backend.entities.message.Dialogue;
+import com.speakfluid.backend.entities.message.DialogueList;
 import com.speakfluid.backend.entities.message.Transcript;
 import com.speakfluid.backend.entities.message.WozMessage;
 import com.speakfluid.backend.entities.steps.*;
@@ -23,7 +24,7 @@ import java.util.Map;
  */
 
 // Use Case Layer
-public class WozWozTranscriptAnalysisInteractor implements WozTranscriptAnalysisInputBoundary {
+public class WozTranscriptAnalysisInteractor implements WozTranscriptAnalysisInputBoundary {
 
     // Generate all TalkStep entities,except Card
     ButtonStep buttonStep = new ButtonStep();
@@ -58,14 +59,13 @@ public class WozWozTranscriptAnalysisInteractor implements WozTranscriptAnalysis
      * @return the analyzed transcript which contains Dialogue objects with updated stepSuggestion and confidenceScore.
      */
     @Override
-    public ArrayList<HashMap<String, ArrayList<Dialogue<WozMessage>>>> analyzeTranscript(
-            ArrayList<HashMap<String, ArrayList<Dialogue<WozMessage>>>> transcript) {
+    public ArrayList<Transcript> analyzeTranscript(ArrayList<Transcript> transcript) {
 
         // To access all the different id-to-conversation-content pairs in the same session
-        for (HashMap<String, ArrayList<Dialogue<WozMessage>>> idToConversations : transcript) {
+        for (Transcript idToConversations : transcript) {
 
             // To access the conversations in the id-to-conversation-content pairs
-            for (ArrayList<Dialogue<WozMessage>> conversation : idToConversations.values()) {
+            for (DialogueList conversation : idToConversations.values()) {
 
                 // To access each back and forth dialogue within each conversation
                 for (Dialogue<WozMessage> dialogue : conversation) {
@@ -97,10 +97,5 @@ public class WozWozTranscriptAnalysisInteractor implements WozTranscriptAnalysis
                 }
             }
         } return transcript;
-    }
-
-    @Override
-    public ArrayList<Transcript> analyzeTranscript(ArrayList<Transcript> transcript) {
-        return null;
     }
 }

--- a/backend/src/test/java/com/speakfluid/backend/entities/ButtonStepTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/ButtonStepTests.java
@@ -1,0 +1,173 @@
+package com.speakfluid.backend.entities;
+import com.speakfluid.backend.entities.steps.*;
+import com.speakfluid.backend.entities.message.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+/**
+ * Test suite for the ButtonStep entity. Using a variety of Dialogue objects of various suitability for a button choice.
+ * Also incorporates testing for the edge case of an empty Dialogue object.
+ *
+ * @author Aurora Zhang
+ * @version 2.0
+ * @since November 25th, 2022
+ */
+
+
+
+public class ButtonStepTests {
+    ButtonStep button;
+    WozMessage user1;
+    WozMessage chat1;
+    WozMessage user2;
+    WozMessage chat2;
+    WozMessage user3;
+    WozMessage chat3;
+
+    WozMessage chat4;
+
+    WozMessage user4;
+
+    // initialize array to an empty ArrayList otherwise default value is null.
+    ArrayList<WozMessage> userMsgs1 = new ArrayList<>();
+    ArrayList<WozMessage> chatbotMsgs1 = new ArrayList<>();
+    ArrayList<WozMessage> userMsgs2 = new ArrayList<>();
+    ArrayList<WozMessage> chatbotMsgs2 = new ArrayList<>();
+    ArrayList<WozMessage> userMsgs3 = new ArrayList<>();
+    ArrayList<WozMessage> chatbotMsgs3 = new ArrayList<>();
+
+    ArrayList<WozMessage> chatbotMsgs4 = new ArrayList<>();
+
+    ArrayList<WozMessage> userMsgs4 = new ArrayList<>();
+
+    Dialogue<?> dialogue1;
+    Dialogue<?> dialogue2;
+    Dialogue<?> dialogue3;
+
+    Dialogue<?> dialogue4;
+
+
+
+    @BeforeEach
+    void init() {
+        //initialize each object with a value before each test.
+        button = new ButtonStep();
+        user1 = new WozMessage("request", "good evening, i need help with" +
+                "my lower back pain.");
+        chat1 = new WozMessage("response", "here are some possible remedies for lower" +
+                "back pain. would you like me to list them for you?");
+        user2 = new WozMessage("request", "no, i think i need to go to the hospital. how " +
+                "do i go to the nearest one?");
+        chat2 =  new WozMessage("response", "here are a list of your nearest hospitals. " +
+                "choose the one that you would like");
+        user3 = new WozMessage("request", "i will go to the first one thank you.");
+        chat3 = new WozMessage("response", "you're welcome. have a nice day.");
+        user4 = new WozMessage("request","");
+        chat4 = new WozMessage("response","");
+
+
+
+        chatbotMsgs1.add(chat1);
+        chatbotMsgs2.add(chat2);
+        chatbotMsgs3.add(chat3);
+        chatbotMsgs4.add(chat4);
+
+        userMsgs2.add(user2);
+        userMsgs3.add(user3);
+        userMsgs4.add(user4);
+
+
+        dialogue1 = new Dialogue<>(chatbotMsgs1, userMsgs1);
+        dialogue2 = new Dialogue<>(chatbotMsgs2, userMsgs2);
+        dialogue3 = new Dialogue<>(chatbotMsgs3, userMsgs3);
+        dialogue4 = new Dialogue<>(chatbotMsgs4, userMsgs4);
+
+    }
+
+    @AfterEach
+    public void reset() {
+        // because each message is added before each test, we must clear them to prevent it from repeating.
+        userMsgs1.clear();
+        chatbotMsgs1.clear();
+        userMsgs2.clear();
+        chatbotMsgs2.clear();
+        userMsgs3.clear();
+        chatbotMsgs3.clear();
+        chatbotMsgs4.clear();
+        userMsgs4.clear();
+    }
+
+    @Test
+    void testGetStepName(){
+        String expected = "Button";
+        String actual = button.getStepName();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void setZeroScoreAccumulator(){
+        double expected = 0.0;
+        button.runAnalysis(dialogue1);
+        button.setZeroScoreAccumulator();
+        double actual = button.getScoreAccumulator();
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    void testGetMaxScore(){
+        double expected = 15.0;
+        double actual = button.getMaxScore();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testGetScoreAccumulator(){
+        double expected = 0.0;
+        double actual = button.getScoreAccumulator();
+        assertEquals(expected, actual);
+
+    }
+
+    /*the scoreAccumulator is allowed to exceed the maxscore in our program, in which case
+    the capping mechanism in ConfidenceScoreCalculator will revert it to a rate of 95%
+     */
+
+    @Test
+    void testButtonRunAnalysisDialogue1(){
+        button.runAnalysis(dialogue1);
+        double expected = 10.0;
+        double actual = button.getScoreAccumulator();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testButtonRunAnalysisDialogue2(){
+        button.runAnalysis(dialogue2);
+        double expected = 16.0;
+        double actual = button.getScoreAccumulator();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testButtonRunAnalysisDialogue3(){
+        button.runAnalysis(dialogue3);
+        double expected = 3.0;
+        double actual = button.getScoreAccumulator();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testButtonRunAnalysisDialogue4Empty(){
+        button.runAnalysis(dialogue4);
+        double expected = 0.0;
+        double actual = button.getScoreAccumulator();
+        assertEquals(expected, actual);
+    }
+
+}

--- a/backend/src/test/java/com/speakfluid/backend/entities/CaptureStepTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/CaptureStepTests.java
@@ -4,20 +4,11 @@ import com.speakfluid.backend.entities.message.Dialogue;
 import com.speakfluid.backend.entities.message.WozMessage;
 import com.speakfluid.backend.entities.steps.CaptureStep;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
-
-import java.awt.*;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
-
-import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
+
 
 /**
  * Tests for the Dialogue class.

--- a/backend/src/test/java/com/speakfluid/backend/entities/CardStepTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/CardStepTests.java
@@ -1,0 +1,162 @@
+package com.speakfluid.backend.entities;
+import com.speakfluid.backend.entities.steps.*;
+import com.speakfluid.backend.entities.message.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+
+
+/*
+ * Test suite for the CardStep entity. Using a variety of Dialogue objects of various suitability for a card choice.
+ * Also incorporates testing for the edge case of an empty Dialogue object.
+ *
+ * @author Aurora Zhang
+ * @version 2.0
+ * @since November 27th, 2022
+ */
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+
+public class CardStepTests {
+    CardStep card;
+    WozMessage user1;
+    WozMessage chat1;
+    WozMessage user2;
+    WozMessage chat2;
+    WozMessage user3;
+    WozMessage chat3;
+
+    WozMessage user4;
+    WozMessage chat4;
+
+    // initialize arrays to an empty ArrayList otherwise default value is null.
+    ArrayList<WozMessage> userMsgs1 = new ArrayList<>();
+    ArrayList<WozMessage> chatbotMsgs1 = new ArrayList<>();
+    ArrayList<WozMessage> userMsgs2 = new ArrayList<>();
+    ArrayList<WozMessage> chatbotMsgs2 = new ArrayList<>();
+    ArrayList<WozMessage> userMsgs3 = new ArrayList<>();
+    ArrayList<WozMessage> chatbotMsgs3 = new ArrayList<>();
+
+    ArrayList<WozMessage> chatbotMsgs4 = new ArrayList<>();
+
+    ArrayList<WozMessage> userMsgs4 = new ArrayList<>();
+
+    Dialogue<?> dialogue1;
+    Dialogue<?> dialogue2;
+    Dialogue<?> dialogue3;
+
+    Dialogue<?> dialogue4;
+
+
+    @BeforeEach
+    void init(){
+        card = new CardStep();
+        user1 = new WozMessage("request", "i am looking for the most famous art gallery in this area." +
+                "can you tell me some suggestions?");
+        chat1 = new WozMessage("response", "there are many near you. choose the one you would like.");
+        user2 = new WozMessage("request", "can you find the ones that have hotels nearby?");
+        chat2 = new WozMessage("response", "yes. the regency hotel is near the fine arts museum. would" +
+                "you like to choose this?");
+        user3 = new WozMessage("request","yes. thank you");
+        chat3 = new WozMessage("response", "okay it is booked. thank you and have a good day.");
+        user4 = new WozMessage("request","");
+        chat4 = new WozMessage("response","");
+
+        chatbotMsgs1.add(chat1);
+        chatbotMsgs2.add(chat2);
+        chatbotMsgs3.add(chat3);
+        chatbotMsgs4.add(chat4);
+
+
+
+        userMsgs2.add(user2);
+        userMsgs3.add(user3);
+        userMsgs4.add(user4);
+
+
+        dialogue1 = new Dialogue<>(chatbotMsgs1, userMsgs1);
+        dialogue2 = new Dialogue<>(chatbotMsgs2, userMsgs2);
+        dialogue3 = new Dialogue<>(chatbotMsgs3, userMsgs3);
+        dialogue4 = new Dialogue<>(chatbotMsgs4, userMsgs4);
+    }
+
+    @AfterEach
+    public void reset(){
+        // because each message is added before each test, we must clear them to prevent it from repeating.
+        userMsgs1.clear();
+        chatbotMsgs1.clear();
+        userMsgs2.clear();
+        chatbotMsgs2.clear();
+        userMsgs3.clear();
+        chatbotMsgs3.clear();
+        chatbotMsgs4.clear();
+        userMsgs4.clear();
+
+    }
+
+    @Test
+    void setZeroScoreAccumulator(){
+        double expected = 0.0;
+        card.runAnalysis(dialogue2);
+        card.setZeroScoreAccumulator();
+        double actual = card.getScoreAccumulator();
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    void testGetMaxScore(){
+        double expected = 15.0;
+        double actual = card.getMaxScore();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testGetScoreAccumulator(){
+        double expected = 0.0;
+        double actual = card.getScoreAccumulator();
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    void testCardRunAnalysisDialogue1(){
+        card.runAnalysis(dialogue1);
+        double expected = 11.0;
+        double actual = card.getScoreAccumulator();
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    void testCardRunAnalysisDialogue2(){
+        card.runAnalysis(dialogue2);
+        double expected = 10.0;
+        double actual = card.getScoreAccumulator();
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    void testCardRunAnalysisDialogue3(){
+        card.runAnalysis(dialogue3);
+        //this makes sense as dialogue2 is just ending the conversation
+        double expected = 0.0;
+        double actual = card.getScoreAccumulator();
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    public void testCardRunAnalysisDialogue4Empty(){
+        card.runAnalysis(dialogue4);
+        double expected = 0.0;
+        double actual = card.getScoreAccumulator();
+        assertEquals(expected, actual);
+    }
+
+
+
+}

--- a/backend/src/test/java/com/speakfluid/backend/entities/CarouselStepTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/CarouselStepTests.java
@@ -1,8 +1,10 @@
 package com.speakfluid.backend.entities;
 
 import com.speakfluid.backend.entities.message.Dialogue;
+import com.speakfluid.backend.entities.*;
 import com.speakfluid.backend.entities.message.WozMessage;
-import com.speakfluid.backend.entities.steps.CarouselStep;
+import com.speakfluid.backend.entities.steps.*;
+import com.speakfluid.backend.entities.message.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 

--- a/backend/src/test/java/com/speakfluid/backend/entities/ConfidenceScoreCalculatorTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/ConfidenceScoreCalculatorTests.java
@@ -1,0 +1,215 @@
+package com.speakfluid.backend.entities;
+import com.speakfluid.backend.entities.steps.*;
+import com.speakfluid.backend.entities.message.*;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test suite for the ConfidenceScoreCalculator entity, using various TalkStep instances and Dialogue objects of
+ * various suitability for each TalkStep object to test for a wide range of confidence scores.
+ *
+ * @author Aurora Zhang
+ * @version 1.0
+ * @since November 28th, 2022
+ */
+
+public class ConfidenceScoreCalculatorTests {
+
+    static ConfidenceScoreCalculator calculator;
+
+    static WozMessage user1;
+    static WozMessage chat1;
+    static WozMessage user2;
+    static WozMessage chat2;
+    static WozMessage user3;
+    static WozMessage chat3;
+    static WozMessage chat4;
+    static WozMessage user4;
+
+    static ArrayList<WozMessage> userMsgs1 = new ArrayList<>();
+    static ArrayList<WozMessage> chatbotMsgs1 = new ArrayList<>();
+    static ArrayList<WozMessage> userMsgs2 = new ArrayList<>();
+    static ArrayList<WozMessage> chatbotMsgs2 = new ArrayList<>();
+    static ArrayList<WozMessage> userMsgs3 = new ArrayList<>();
+    static ArrayList<WozMessage> chatbotMsgs3 = new ArrayList<>();
+
+    static ArrayList<WozMessage> userMsgs4 = new ArrayList<>();
+    static ArrayList<WozMessage> chatbotMsgs4 = new ArrayList<>();
+
+    static Dialogue<?> dialogue1;
+    static Dialogue<?> dialogue2;
+    static Dialogue<?> dialogue3;
+
+    static Dialogue<?> dialogue4;
+    static ButtonStep button;
+    static CardStep card;
+
+    @BeforeAll
+    public static  void setUp(){
+        calculator = new ConfidenceScoreCalculator();
+        button = new ButtonStep();
+        card = new CardStep();
+
+        user1 = new WozMessage("request", "good evening, i need help with" +
+                "my lower back pain.");
+        chat1 = new WozMessage("response", "here are some possible remedies for lower" +
+                "back pain. would you like me to list them for you?");
+        user2 = new WozMessage("request", "no, i think i need to go to the hospital. how " +
+                "do i go to the nearest one?");
+        chat2 =  new WozMessage("response", "here are a list of your nearest hospitals. " +
+                "choose the one that you would like");
+        user3 = new WozMessage("request", "i will go to the first one thank you.");
+        chat3 = new WozMessage("response", "you're welcome. have a nice day.");
+        user4 = new WozMessage("request","");
+        chat4 = new WozMessage("response","");
+
+        chatbotMsgs1.add(chat1);
+        chatbotMsgs2.add(chat2);
+        chatbotMsgs3.add(chat3);
+        chatbotMsgs4.add(chat4);
+
+        userMsgs2.add(user2);
+        userMsgs3.add(user3);
+        userMsgs4.add(user4);
+
+
+        dialogue1 = new Dialogue<>(chatbotMsgs1, userMsgs1);
+        dialogue2 = new Dialogue<>(chatbotMsgs2, userMsgs2);
+        dialogue3 = new Dialogue<>(chatbotMsgs3, userMsgs3);
+        dialogue4 = new Dialogue<>(chatbotMsgs4, userMsgs4);
+    }
+
+    @Test
+    public void testPassDialogue1ToTalkStepButton(){
+        calculator.passDialogueToTalkStep(dialogue1, button);
+        double actual = calculator.stepScoreAccumulator;
+        double expected = 10.0;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testPassDialogue1ToTalkStepCard(){
+        calculator.passDialogueToTalkStep(dialogue1, card);
+        double actual = calculator.stepScoreAccumulator;
+        //makes sense the accumulated score is correspondingly low when this
+        //dialogue was made for button suitability
+        double expected = 3.0;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testPassDialogue2ToTalkStepButton(){
+        calculator.passDialogueToTalkStep(dialogue2, button);
+        double actual = calculator.stepScoreAccumulator;
+        double expected = 16.0;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testPassDialogue2ToTalkStepCard(){
+        calculator.passDialogueToTalkStep(dialogue2, card);
+        double actual = calculator.stepScoreAccumulator;
+        //the card step here can also be suitable as it is listing the nearby hospitals and images the user
+        //can click on may be helpful
+        double expected = 13.0;
+        assertEquals(expected, actual);
+    }
+
+    // both tests have low accumulated scores because niether is supposed to be suitable for dialogue3.
+    @Test
+    public void testPassDialogue3ToTalkStepButton(){
+        calculator.passDialogueToTalkStep(dialogue3, button);
+        double actual = calculator.stepScoreAccumulator;
+        double expected = 3.0;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testPassDialogue3ToTalkStepCard(){
+        calculator.passDialogueToTalkStep(dialogue3, card);
+        double actual = calculator.stepScoreAccumulator;
+        double expected = 4.0;
+        assertEquals(expected, actual);
+    }
+
+    //Dialogue4 is empty so testing this edge case should ensure the score accumulated is 0 as desired.
+    @Test
+    public void testPassDialogue4ToTalkStepButton(){
+        calculator.passDialogueToTalkStep(dialogue4, button);
+        double actual = calculator.stepScoreAccumulator;
+        double expected = 0.0;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testPassDialogue4ToTalkStepCard(){
+        calculator.passDialogueToTalkStep(dialogue4, card);
+        double actual = calculator.stepScoreAccumulator;
+        double expected = 0.0;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCalculateConfidenceScoreButton1(){
+        calculator.passDialogueToTalkStep(dialogue1, button);
+        double actual = calculator.calculateConfidenceScore();
+        double expected = 66.67;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCalculateConfidenceScoreButton2(){
+        calculator.passDialogueToTalkStep(dialogue2, button);
+        double actual = calculator.calculateConfidenceScore();
+        double expected = 95.0;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCalculateConfidenceScoreButton3(){
+        calculator.passDialogueToTalkStep(dialogue3, button);
+        double actual = calculator.calculateConfidenceScore();
+        //this makes sense that it is low as dialogue3 is ending the conversation
+        double expected = 20.0;
+        assertEquals(expected, actual);
+    }
+    @Test
+    public void testCalculateConfidenceScoreButton4(){
+        calculator.passDialogueToTalkStep(dialogue4, card);
+        double actual = calculator.calculateConfidenceScore();
+        double expected = 0;
+        assertEquals(expected, actual);
+    }
+
+    @Test
+    public void testCalculateConfidenceScoreCard1(){
+        calculator.passDialogueToTalkStep(dialogue1, card);
+        double actual = calculator.calculateConfidenceScore();
+        double expected = 20.0;
+        assertEquals(expected, actual);
+    }
+    @Test
+    public void testCalculateConfidenceScoreCard2(){
+        calculator.passDialogueToTalkStep(dialogue2, card);
+        double actual = calculator.calculateConfidenceScore();
+        double expected = 86.67;
+        assertEquals(expected, actual);
+    }
+    @Test
+    public void testCalculateConfidenceScoreCard3(){
+        calculator.passDialogueToTalkStep(dialogue3, card);
+        double actual = calculator.calculateConfidenceScore();
+        double expected = 26.67;
+        assertEquals(expected, actual);
+    }
+    @Test
+    public void testCalculateConfidenceScoreCard4(){
+        calculator.passDialogueToTalkStep(dialogue4, card);
+        double actual = calculator.calculateConfidenceScore();
+        double expected = 0;
+        assertEquals(expected, actual);
+    }
+
+}

--- a/backend/src/test/java/com/speakfluid/backend/entities/ConfidenceScoreOptimizerTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/ConfidenceScoreOptimizerTests.java
@@ -1,0 +1,290 @@
+package com.speakfluid.backend.entities;
+import com.speakfluid.backend.entities.steps.*;
+import com.speakfluid.backend.entities.message.*;
+
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * Test suite for the ConfidenceScoreOptimizer class, which tests all TalkStep entities using a variety of Dialogues
+ * suited for different TalkSteps. Tests the methods callConfidenceScoreCalculator and rankTalkSteps.
+ *
+ * @author Aurora Zhang
+ * @version 1.0
+ * @since November 28th, 2022
+ */
+
+public class ConfidenceScoreOptimizerTests {
+    static WozMessage user1;
+    static WozMessage chat1;
+    static WozMessage user2;
+    static WozMessage chat2;
+    static WozMessage user3;
+    static WozMessage chat3;
+    static WozMessage chat4;
+    static WozMessage user4;
+
+    static ArrayList<WozMessage> userMsgs1 = new ArrayList<>();
+    static ArrayList<WozMessage> chatbotMsgs1 = new ArrayList<>();
+    static ArrayList<WozMessage> userMsgs2 = new ArrayList<>();
+    static ArrayList<WozMessage> chatbotMsgs2 = new ArrayList<>();
+    static ArrayList<WozMessage> userMsgs3 = new ArrayList<>();
+    static ArrayList<WozMessage> chatbotMsgs3 = new ArrayList<>();
+
+    static ArrayList<WozMessage> userMsgs4 = new ArrayList<>();
+    static ArrayList<WozMessage> chatbotMsgs4 = new ArrayList<>();
+
+    static Dialogue<?> dialogue1;
+    static Dialogue<?> dialogue2;
+    static Dialogue<?> dialogue3;
+    static Dialogue<?> dialogue4;
+
+    static ButtonStep button;
+    static CardStep card;
+    static TextStep text;
+    static CarouselStep carousel;
+    static CaptureStep capture;
+    static ImageStep image;
+    static ChoiceStep choice;
+
+    static ArrayList<TalkStep> talkStepList = new ArrayList<>();
+
+    static ConfidenceScoreOptimizer optimizer;
+    static ConfidenceScoreCalculator calculator2;
+
+    @BeforeAll
+    static void setUp(){
+
+        user1 = new WozMessage("request", "good evening, i need help with" +
+                "my lower back pain.");
+        chat1 = new WozMessage("response", "here are some possible remedies for lower" +
+                "back pain. would you like me to list them for you?");
+        user2 = new WozMessage("request", "no, i think i need to go to the hospital. how " +
+                "do i go to the nearest one?");
+        chat2 =  new WozMessage("response", "here are a list of your nearest hospitals. " +
+                "choose the one that you would like");
+        user3 = new WozMessage("request", "i will go to the first one thank you.");
+        chat3 = new WozMessage("response", "you're welcome. have a nice day.");
+        user4 = new WozMessage("request","");
+        chat4 = new WozMessage("response","");
+
+        chatbotMsgs1.add(chat1);
+        chatbotMsgs2.add(chat2);
+        chatbotMsgs3.add(chat3);
+        chatbotMsgs4.add(chat4);
+
+        userMsgs2.add(user2);
+        userMsgs3.add(user3);
+        userMsgs4.add(user4);
+
+
+        dialogue1 = new Dialogue<>(chatbotMsgs1, userMsgs1);
+        dialogue2 = new Dialogue<>(chatbotMsgs2, userMsgs2);
+        dialogue3 = new Dialogue<>(chatbotMsgs3, userMsgs3);
+        dialogue4 = new Dialogue<>(chatbotMsgs4, userMsgs4);
+
+    }
+
+    @BeforeEach
+    void init(){
+        button = new ButtonStep();
+        card = new CardStep();
+        text = new TextStep();
+        carousel = new CarouselStep();
+        capture = new CaptureStep();
+        image = new ImageStep();
+        choice = new ChoiceStep();
+
+        Collections.addAll(talkStepList, button, card, carousel, capture, image, choice, text);
+        calculator2 = new ConfidenceScoreCalculator();
+        optimizer = new ConfidenceScoreOptimizer(calculator2, talkStepList);
+
+    }
+
+    @AfterEach
+    public void reset(){
+        talkStepList.clear();
+    }
+    @Test
+    public void testCallConfidenceScoreOptimizer1(){
+        optimizer.callConfidenceScoreCalculator(dialogue1);
+        HashMap<String, Double> actual = optimizer.talkStepToScoreMapping;
+        HashMap<String, Double> expected = new HashMap<>(){{
+            put("Button", 66.67);
+            put("Carousel", 68.75);
+            put("Image", 0.0);
+            put("Capture", 0.0);
+            put("Card", 20.0);
+            put("Choice", 66.67);
+            put("Text", 16.95);
+        }};
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    public void testCallConfidenceScoreOptimizer2(){
+        optimizer.callConfidenceScoreCalculator(dialogue2);
+        HashMap<String, Double> actual = optimizer.talkStepToScoreMapping;
+        HashMap<String, Double> expected = new HashMap<>(){{
+            put("Button", 95.0);
+            put("Carousel", 95.0);
+            put("Image", 0.0);
+            put("Capture", 0.0);
+            put("Card", 86.67);
+            put("Text", 25.42);
+            put("Choice", 33.33);
+        }};
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    public void testCallConfidenceScoreOptimizer3(){
+        optimizer.callConfidenceScoreCalculator(dialogue3);
+        HashMap<String, Double> actual = optimizer.talkStepToScoreMapping;
+        HashMap<String, Double> expected = new HashMap<>(){{
+            put("Button", 20.0);
+            put("Carousel", 31.25);
+            put("Image", 0.0);
+            put("Capture", 4.76);
+            put("Card", 26.67);
+            put("Text", 16.95);
+            put("Choice", 0.0);
+        }};
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    public void testCallConfidenceScoreOptimizer4(){
+        optimizer.callConfidenceScoreCalculator(dialogue4);
+        HashMap<String, Double> actual = optimizer.talkStepToScoreMapping;
+        HashMap<String, Double> expected = new HashMap<>(){{
+            put("Button", 0.0);
+            put("Carousel", 0.0);
+            put("Image", 0.0);
+            put("Capture", 0.0);
+            put("Card", 0.0);
+            put("Choice", 0.0);
+            put("Text", 16.95);
+        }};
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    public void testRankTalkSteps1(){
+        optimizer.callConfidenceScoreCalculator(dialogue1);
+        ArrayList<Map<String, Double>> actual = optimizer.rankTalkSteps();
+        HashMap<String, Double> step1 = new HashMap<>();
+        HashMap<String, Double> step2 = new HashMap<>();
+        HashMap<String, Double> step3 = new HashMap<>();
+        HashMap<String, Double> step4 = new HashMap<>();
+        HashMap<String, Double> step5 = new HashMap<>();
+        HashMap<String, Double> step6 = new HashMap<>();
+        HashMap<String, Double> step7 = new HashMap<>();
+
+        step1.put("Carousel", 68.75);
+        step2.put("Button", 66.67);
+        step3.put("Card", 20.0);
+        step4.put("Capture", 0.0);
+        step5.put("Image", 0.0);
+        step6.put("Text", 16.95);
+        step7.put("Choice", 66.67);
+
+        ArrayList<Map<String, Double>> expected = new ArrayList<>();
+        Collections.addAll(expected, step1, step2, step7, step3, step6, step4, step5);
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    public void testRankTalkSteps2(){
+        optimizer.callConfidenceScoreCalculator(dialogue2);
+        ArrayList<Map<String, Double>> actual = optimizer.rankTalkSteps();
+        HashMap<String, Double> step1 = new HashMap<>();
+        HashMap<String, Double> step2 = new HashMap<>();
+        HashMap<String, Double> step3 = new HashMap<>();
+        HashMap<String, Double> step4 = new HashMap<>();
+        HashMap<String, Double> step5 = new HashMap<>();
+        HashMap<String, Double> step6 = new HashMap<>();
+        HashMap<String, Double> step7 = new HashMap<>();
+
+        step1.put("Carousel", 95.0);
+        step2.put("Button", 95.0);
+        step3.put("Card", 86.67);
+        step4.put("Capture", 0.0);
+        step5.put("Image", 0.0);
+        step6.put("Text", 25.42);
+        step7.put("Choice", 33.33);
+
+        ArrayList<Map<String, Double>> expected = new ArrayList<>();
+        Collections.addAll(expected, step1, step2, step3, step7, step6, step4, step5);
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    public void testRankTalkSteps3(){
+        optimizer.callConfidenceScoreCalculator(dialogue3);
+        ArrayList<Map<String, Double>> actual = optimizer.rankTalkSteps();
+        HashMap<String, Double> step1 = new HashMap<>();
+        HashMap<String, Double> step2 = new HashMap<>();
+        HashMap<String, Double> step3 = new HashMap<>();
+        HashMap<String, Double> step4 = new HashMap<>();
+        HashMap<String, Double> step5 = new HashMap<>();
+        HashMap<String, Double> step6 = new HashMap<>();
+        HashMap<String, Double> step7 = new HashMap<>();
+
+        step1.put("Carousel", 31.25);
+        step2.put("Button", 20.0);
+        step3.put("Card", 26.67);
+        step4.put("Capture", 4.76);
+        step5.put("Image", 0.0);
+        step6.put("Text", 16.95);
+        step7.put("Choice", 0.0);
+
+        ArrayList<Map<String, Double>> expected = new ArrayList<>();
+        Collections.addAll(expected, step1, step3, step2, step6, step4, step5, step7);
+        assertEquals(expected, actual);
+
+    }
+
+    @Test
+    public void testRankTalkSteps4(){
+        optimizer.callConfidenceScoreCalculator(dialogue4);
+        ArrayList<Map<String, Double>> actual = optimizer.rankTalkSteps();
+        HashMap<String, Double> step1 = new HashMap<>();
+        HashMap<String, Double> step2 = new HashMap<>();
+        HashMap<String, Double> step3 = new HashMap<>();
+        HashMap<String, Double> step4 = new HashMap<>();
+        HashMap<String, Double> step5 = new HashMap<>();
+        HashMap<String, Double> step6 = new HashMap<>();
+        HashMap<String, Double> step7 = new HashMap<>();
+
+        step1.put("Carousel", 0.0);
+        step2.put("Button", 0.0);
+        step3.put("Card", 0.0);
+        step4.put("Capture", 0.0);
+        step5.put("Image", 0.0);
+        step6.put("Text", 16.95);
+        step7.put("Choice", 0.0);
+
+        ArrayList<Map<String, Double>> expected = new ArrayList<>();
+        Collections.addAll(expected, step6, step3, step4, step5, step1, step2, step7);
+        assertEquals(expected, actual);
+
+    }
+
+
+}

--- a/backend/src/test/java/com/speakfluid/backend/entities/ConfidenceScoreOptimizerTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/ConfidenceScoreOptimizerTests.java
@@ -120,12 +120,12 @@ public class ConfidenceScoreOptimizerTests {
         HashMap<String, Double> actual = optimizer.talkStepToScoreMapping;
         HashMap<String, Double> expected = new HashMap<>(){{
             put("Button", 66.67);
-            put("Carousel", 68.75);
+            put("Carousel", 70.0);
             put("Image", 0.0);
             put("Capture", 0.0);
             put("Card", 20.0);
             put("Choice", 66.67);
-            put("Text", 16.95);
+            put("Text", 11.54);
         }};
         assertEquals(expected, actual);
 
@@ -141,7 +141,7 @@ public class ConfidenceScoreOptimizerTests {
             put("Image", 0.0);
             put("Capture", 0.0);
             put("Card", 86.67);
-            put("Text", 25.42);
+            put("Text", 23.08);
             put("Choice", 33.33);
         }};
         assertEquals(expected, actual);
@@ -154,11 +154,11 @@ public class ConfidenceScoreOptimizerTests {
         HashMap<String, Double> actual = optimizer.talkStepToScoreMapping;
         HashMap<String, Double> expected = new HashMap<>(){{
             put("Button", 20.0);
-            put("Carousel", 31.25);
+            put("Carousel", 0.0);
             put("Image", 0.0);
             put("Capture", 4.76);
             put("Card", 26.67);
-            put("Text", 16.95);
+            put("Text", 38.46);
             put("Choice", 0.0);
         }};
         assertEquals(expected, actual);
@@ -176,7 +176,7 @@ public class ConfidenceScoreOptimizerTests {
             put("Capture", 0.0);
             put("Card", 0.0);
             put("Choice", 0.0);
-            put("Text", 16.95);
+            put("Text", 19.23);
         }};
         assertEquals(expected, actual);
 
@@ -194,12 +194,12 @@ public class ConfidenceScoreOptimizerTests {
         HashMap<String, Double> step6 = new HashMap<>();
         HashMap<String, Double> step7 = new HashMap<>();
 
-        step1.put("Carousel", 68.75);
+        step1.put("Carousel", 70.0);
         step2.put("Button", 66.67);
         step3.put("Card", 20.0);
         step4.put("Capture", 0.0);
         step5.put("Image", 0.0);
-        step6.put("Text", 16.95);
+        step6.put("Text", 11.54);
         step7.put("Choice", 66.67);
 
         ArrayList<Map<String, Double>> expected = new ArrayList<>();
@@ -225,7 +225,7 @@ public class ConfidenceScoreOptimizerTests {
         step3.put("Card", 86.67);
         step4.put("Capture", 0.0);
         step5.put("Image", 0.0);
-        step6.put("Text", 25.42);
+        step6.put("Text", 23.08);
         step7.put("Choice", 33.33);
 
         ArrayList<Map<String, Double>> expected = new ArrayList<>();
@@ -246,16 +246,16 @@ public class ConfidenceScoreOptimizerTests {
         HashMap<String, Double> step6 = new HashMap<>();
         HashMap<String, Double> step7 = new HashMap<>();
 
-        step1.put("Carousel", 31.25);
-        step2.put("Button", 20.0);
-        step3.put("Card", 26.67);
+        step1.put("Text", 38.46);
+        step2.put("Card", 26.67);
+        step3.put("Button", 20.0);
         step4.put("Capture", 4.76);
         step5.put("Image", 0.0);
-        step6.put("Text", 16.95);
+        step6.put("Carousel", 0.0);
         step7.put("Choice", 0.0);
 
         ArrayList<Map<String, Double>> expected = new ArrayList<>();
-        Collections.addAll(expected, step1, step3, step2, step6, step4, step5, step7);
+        Collections.addAll(expected, step1, step2, step3, step4, step5, step6, step7);
         assertEquals(expected, actual);
 
     }
@@ -277,7 +277,7 @@ public class ConfidenceScoreOptimizerTests {
         step3.put("Card", 0.0);
         step4.put("Capture", 0.0);
         step5.put("Image", 0.0);
-        step6.put("Text", 16.95);
+        step6.put("Text", 19.23);
         step7.put("Choice", 0.0);
 
         ArrayList<Map<String, Double>> expected = new ArrayList<>();


### PR DESCRIPTION
amended ConfidenceScoreOptimizer to return the ranked talksteps by their confidence score in decreasing order as an ArrayList of Maps. Made the corresponding changes to WozWozTranscriptAnalysisInteractor to be compatible with these changes so that the same functionality remains.

-A capping feature was implemented on ConfidenceScoreCalculator so no percentages exceeding greater than 100 was returned
-ConfidenceScoreCalculator also now rounds the confidence score to 2 decimal places.

Notes for the Testing:
-full coverage testing for every line for the entities ButtonStep, CardStep, ConfidenceScoreOptimizer, ConfidenceScoreCalculator
This was done with a variety of dialogues suitable for specific TalkSteps to demonstrate suitability.
-max scores for ButtonStep and CardStep were amended to provide more accurate results