### PR TITLE
Resolved all warnings, fixed bug created by PR#102.

### DIFF
--- a/backend/src/main/java/com/speakfluid/backend/controller/TranscriptController.java
+++ b/backend/src/main/java/com/speakfluid/backend/controller/TranscriptController.java
@@ -47,7 +47,7 @@ public class TranscriptController {
     @PostMapping("/upload")
     public ResponseEntity<?> upload(@RequestParam("transcript")MultipartFile transcript) throws IOException {
         // This uploads the raw transcript to the DB and stores the id of the raw transcript in reponse.
-        String rawTranscriptId = transcriptService.addTranscript(transcript);
+        transcriptService.addTranscript(transcript);
                 
         // Transcript here is of type MultipartFile and is coming directly from the @RequestParam.
         WozTranscriptParser parser = new WozTranscriptParser();

--- a/backend/src/main/java/com/speakfluid/backend/entities/ConfidenceScoreCalculator.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/ConfidenceScoreCalculator.java
@@ -2,8 +2,6 @@ package com.speakfluid.backend.entities;
 import com.speakfluid.backend.entities.message.*;
 import com.speakfluid.backend.entities.steps.*;
 
-import java.lang.Math.*;
-
 /**
  * ConfidenceScoreCalculator is responsible for calling every method for each child of TalkStep to adjust their
  * corresponding accumulated scores as necessary. It then returns the confidence score of the TalkStep child based on the
@@ -39,10 +37,8 @@ public class ConfidenceScoreCalculator implements Scorable{
      */
     @Override
     public double calculateConfidenceScore() {
-
         if(((stepScoreAccumulator / stepTotalScore) * 100) > 100){
             return 95.0;
-
         }
         else{
             double confidenceScore = (stepScoreAccumulator / stepTotalScore) * 100;

--- a/backend/src/main/java/com/speakfluid/backend/entities/ConfidenceScoreOptimizer.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/ConfidenceScoreOptimizer.java
@@ -3,14 +3,11 @@ import com.speakfluid.backend.entities.message.*;
 import com.speakfluid.backend.entities.steps.*;
 
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
-
 
 /**
  * ConfidenceScoreOptimizer calls the ConfidenceScoreCalculator to store each talk step's confidence score. It then returns a Hashmap mapping
  * the talk step with the highest confidence score to its confidence score. This class is called by the use case interactor.
- * @author Aurora Zhang
+ * @author Aurora Zhang, Kai Zhuang
  * @version 4.0
  * @since November 16th, 2022
  */
@@ -20,9 +17,6 @@ public class ConfidenceScoreOptimizer {
     HashMap<String, Double> talkStepToScoreMapping = new HashMap<>();
     ConfidenceScoreCalculator confidenceScoreCalculator;
     Double stepConfidenceScore;
-    ArrayList<Map<String, Double>> rankedTalkStepList = new ArrayList<>();
-
-
 
     public ConfidenceScoreOptimizer(ConfidenceScoreCalculator confidenceScoreCalculator, ArrayList<TalkStep> stepList) {
         this.confidenceScoreCalculator = confidenceScoreCalculator;
@@ -52,21 +46,20 @@ public class ConfidenceScoreOptimizer {
     public ArrayList<Map<String, Double>> rankTalkSteps() {
         //Sorting the map in increasing order
         LinkedHashMap<String, Double> rankedTalkStepMap = new LinkedHashMap<>();
+        ArrayList<Map<String, Double>> rankedTalkStepList = new ArrayList<>();
 
         talkStepToScoreMapping.entrySet()
-                .stream()
-                .sorted(Map.Entry.comparingByValue())
-                .forEachOrdered(x -> rankedTalkStepMap.put(x.getKey(), x.getValue()));
+            .stream()
+            .sorted(Map.Entry.comparingByValue())
+            .forEachOrdered(x -> rankedTalkStepMap.put(x.getKey(), x.getValue()));
 
         //adding each entry to the front of the list so it will become decreasing order
         for(Map.Entry<String, Double> entry: rankedTalkStepMap.entrySet()){
             HashMap<String, Double> talkStepPair = new HashMap<>();
             talkStepPair.put(entry.getKey(), entry.getValue());
             rankedTalkStepList.add(0, talkStepPair);
-
         }
+
         return rankedTalkStepList;
-
     }
-
 }

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/ButtonStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/ButtonStep.java
@@ -1,6 +1,5 @@
 package com.speakfluid.backend.entities.steps;
 import com.speakfluid.backend.entities.message.*;
-import com.speakfluid.backend.entities.steps.*;
 import com.speakfluid.backend.entities.*;
 
 import java.util.List;

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/CaptureStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/CaptureStep.java
@@ -160,7 +160,7 @@ public class CaptureStep extends TalkStep {
      * the dialogue is compatible with a Capture Step.
      * @param dialogue one back and forth between chatbot and user
      */
-    public void runAnalysis(Dialogue dialogue){
+    public void runAnalysis(Dialogue<?> dialogue){
         // Chatbot messages
         for (Object chatbotMessage : dialogue.getChatBotMessage()){
             scoreAccumulator += countMatchKeywords((Message) chatbotMessage, captureKeyWordsChatbot);

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/CardStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/CardStep.java
@@ -1,6 +1,5 @@
 package com.speakfluid.backend.entities.steps;
 import com.speakfluid.backend.entities.message.*;
-import com.speakfluid.backend.entities.steps.*;
 import com.speakfluid.backend.entities.*;
 
 import java.util.*;

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/CarouselStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/CarouselStep.java
@@ -2,7 +2,6 @@ package com.speakfluid.backend.entities.steps;
 
 import com.speakfluid.backend.entities.*;
 import com.speakfluid.backend.entities.message.*;
-import com.speakfluid.backend.entities.steps.*;
 
 
 import java.util.Arrays;

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/ChoiceStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/ChoiceStep.java
@@ -70,7 +70,7 @@ public class ChoiceStep extends TalkStep {
      * the dialogue is compatible with a Choice Step.
      * @param dialogue one back and forth between chatbot and user
      */
-    public void runAnalysis(Dialogue dialogue) {
+    public void runAnalysis(Dialogue<?> dialogue) {
         // Chatbot messages
         for (Object chatbotMessage : dialogue.getChatBotMessage()){
             scoreAccumulator += countMatchKeywords((Message) chatbotMessage, choiceKeyWordsChatbot);

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/ImageStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/ImageStep.java
@@ -3,7 +3,6 @@ package com.speakfluid.backend.entities.steps;
 import com.speakfluid.backend.entities.ScoreStandards;
 import com.speakfluid.backend.entities.message.Dialogue;
 import com.speakfluid.backend.entities.message.Message;
-import com.speakfluid.backend.entities.steps.*;
 
 import java.util.Arrays;
 import java.util.List;

--- a/backend/src/main/java/com/speakfluid/backend/entities/steps/TextStep.java
+++ b/backend/src/main/java/com/speakfluid/backend/entities/steps/TextStep.java
@@ -16,8 +16,6 @@ import static java.util.Map.entry;
  * Text talk step is mainly used when the bot wants to send a message or a notification to the user
  * and no user response is expected.
  *
- *
- *
  * scoreAccumulator is defined to keep track of how much the dialogue that we are analysing fits each feature of
  * Text talk step.
  * maxScore is setted as the score if the dialogue is compilable perfectly with Text talk step features.

--- a/backend/src/main/java/com/speakfluid/backend/usecases/WozTranscriptAnalysisInputBoundary.java
+++ b/backend/src/main/java/com/speakfluid/backend/usecases/WozTranscriptAnalysisInputBoundary.java
@@ -16,5 +16,4 @@ import java.util.ArrayList;
 public interface WozTranscriptAnalysisInputBoundary {
     public ArrayList<Transcript> analyzeTranscript(
             ArrayList<Transcript> transcript) ;
-
-    }
+}

--- a/backend/src/main/java/com/speakfluid/backend/usecases/WozTranscriptAnalysisInteractor.java
+++ b/backend/src/main/java/com/speakfluid/backend/usecases/WozTranscriptAnalysisInteractor.java
@@ -9,7 +9,6 @@ import com.speakfluid.backend.entities.steps.*;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -44,7 +43,6 @@ public class WozTranscriptAnalysisInteractor implements WozTranscriptAnalysisInp
     // Generate StepManager and SuggestionManager
     ConfidenceScoreCalculator confidenceScoreCalculator = new ConfidenceScoreCalculator();
     ConfidenceScoreOptimizer confidenceScoreOptimizer = new ConfidenceScoreOptimizer(confidenceScoreCalculator, steps);
-
 
     /**
      * analyzeTranscript calls SuggestionManager then stores the suggested talk step and its corresponding confidence
@@ -90,12 +88,12 @@ public class WozTranscriptAnalysisInteractor implements WozTranscriptAnalysisInp
                                 dialogue.addConfidenceScore(confidenceScore);
                             }
                         }
-
-
                     }
 
                 }
             }
-        } return transcript;
+        } 
+        
+        return transcript;
     }
 }

--- a/backend/src/test/java/com/speakfluid/backend/entities/CarouselStepTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/CarouselStepTests.java
@@ -1,10 +1,8 @@
 package com.speakfluid.backend.entities;
 
 import com.speakfluid.backend.entities.message.Dialogue;
-import com.speakfluid.backend.entities.*;
 import com.speakfluid.backend.entities.message.WozMessage;
 import com.speakfluid.backend.entities.steps.*;
-import com.speakfluid.backend.entities.message.*;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.Test;
 
@@ -19,7 +17,7 @@ import static org.junit.jupiter.api.Assertions.*;
  * @version 1.0
  * @since   2022-11-26
  */
-class CarouselStepTests extends TalkStepTest {
+class CarouselStepTests {
     static CarouselStep carouselStep = new CarouselStep();
     static Dialogue<WozMessage> d1;
     static ArrayList<WozMessage> botMsg1;

--- a/backend/src/test/java/com/speakfluid/backend/entities/ChoiceStepTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/ChoiceStepTests.java
@@ -4,20 +4,12 @@ import com.speakfluid.backend.entities.message.Dialogue;
 import com.speakfluid.backend.entities.message.WozMessage;
 import com.speakfluid.backend.entities.steps.ChoiceStep;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
-import java.awt.*;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
 
-import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 /**
  * Tests for the Dialogue class.

--- a/backend/src/test/java/com/speakfluid/backend/entities/DialogueTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/DialogueTests.java
@@ -2,10 +2,8 @@ package com.speakfluid.backend.entities;
 
 import com.speakfluid.backend.entities.message.Dialogue;
 import com.speakfluid.backend.entities.message.WozMessage;
-import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/backend/src/test/java/com/speakfluid/backend/entities/ImageStepTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/ImageStepTests.java
@@ -9,7 +9,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.Mockito.mock;
 
 /**
  * Tests for the ImageStep class.
@@ -18,7 +17,7 @@ import static org.mockito.Mockito.mock;
  * @version 1.0
  * @since   2022-11-26
  */
-class ImageStepTests extends TalkStepTest {
+class ImageStepTests {
     // Class to be tested
     static ImageStep imageStep;
 

--- a/backend/src/test/java/com/speakfluid/backend/entities/MessageTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/MessageTests.java
@@ -2,7 +2,6 @@ package com.speakfluid.backend.entities;
 
 import com.speakfluid.backend.entities.message.Message;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import static org.junit.jupiter.api.Assertions.*;

--- a/backend/src/test/java/com/speakfluid/backend/entities/TalkStepTest.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/TalkStepTest.java
@@ -1,7 +1,0 @@
-package com.speakfluid.backend.entities;
-
-import static org.junit.jupiter.api.Assertions.*;
-
-class TalkStepTest {
-
-}

--- a/backend/src/test/java/com/speakfluid/backend/entities/TalkStepTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/TalkStepTests.java
@@ -5,11 +5,9 @@ import com.speakfluid.backend.entities.message.WozMessage;
 import com.speakfluid.backend.entities.steps.ChoiceStep;
 import com.speakfluid.backend.entities.steps.TalkStep;
 import org.junit.jupiter.api.BeforeAll;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 
-import java.awt.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -17,7 +15,6 @@ import java.util.Map;
 
 import static java.util.Map.entry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.mockito.Mockito.mock;
 
 /**
  * Tests for the Dialogue class.

--- a/backend/src/test/java/com/speakfluid/backend/entities/TextStepTests.java
+++ b/backend/src/test/java/com/speakfluid/backend/entities/TextStepTests.java
@@ -11,7 +11,7 @@ import java.util.Arrays;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-class TextStepTests extends TalkStepTest {
+class TextStepTests {
     static TextStep textStep = new TextStep();
     static Dialogue<WozMessage> d1;
     static Dialogue<WozMessage> d2;

--- a/frontend/src/components/BulletVisualization.tsx
+++ b/frontend/src/components/BulletVisualization.tsx
@@ -14,7 +14,6 @@ import { ChartData } from '../types/Types';
  * @returns A functional component of step suggestions visualized as a bullet chart.
  */
 export default function BulletVisualization({data} : {data: ChartData | any}) {
-
   const config : any = {
     data,
     measureField: 'Confidence',

--- a/frontend/src/pages/Analytics.tsx
+++ b/frontend/src/pages/Analytics.tsx
@@ -75,11 +75,13 @@ export default function Analytics() {
     // Formats the stepSuggestions so they fit the inputs for the bullet graphs.
     const chartData: ChartData[] = []
     suggestion.stepSuggestion.forEach((step: string, index: number) => {
-      chartData.push({title: step, 
-                      ranges: [40,80,100],
-                      Target: [80],
-                      Confidence: [suggestion.confidenceScore[index]], 
-                    })
+      if (suggestion.confidenceScore[index] > 0) {
+        chartData.push({title: step, 
+          ranges: [40, 80, 100],
+          Target: [80],
+          Confidence: [suggestion.confidenceScore[index]], 
+        })
+      }
     })
     s.data = chartData
 


### PR DESCRIPTION
Resolved all warnings:

- Deleted ALL unused imports.
- Changed Dialogue to Dialogue<?> in 2 files to resolve "References to generic type should be parameterized" warning.

Fixed breaking bug from PR#102. ConfidenceScoreOptimizer had a loop variable as a class variable which led to it building an incredibly long list as shown in the attached file.
[message (1).txt](https://github.com/edwardhuahan/tli-speakfluid/files/10129629/message.1.txt)
